### PR TITLE
Use reticulum as the docker repository instead of ret

### DIFF
--- a/.github/workflows/ret-turkey.yml
+++ b/.github/workflows/ret-turkey.yml
@@ -1,4 +1,4 @@
-name: ret
+name: reticulum
 on:
   push:
     branches:


### PR DESCRIPTION
It was decided that continuing to use ret is too obscure and that now is the time to change it before too much history builds up.

Corresponding change for the Community Edition: https://github.com/Hubs-Foundation/hubs-cloud/pull/366