### PR TITLE
Add GitHub workflow file to build/tag/push custom docker images

### DIFF
--- a/.github/workflows/custom-docker-build-push.yml
+++ b/.github/workflows/custom-docker-build-push.yml
@@ -1,0 +1,124 @@
+# Based on the workflow by Brandon Patterson from https://github.com/mikemorran/hubs/blob/master/.github/workflows/ce-build.yml
+# Input masking referenced from https://dev.to/leading-edje/masking-input-parameters-in-github-actions-1ci
+
+# Common registry base URLs:
+# Docker Hub: docker.io
+# GitHub: ghcr.io
+
+name: custom-docker-build-push
+
+on:
+  workflow_dispatch:
+    inputs:
+      Override_Registry_Base_URL:
+        type: string
+      Override_Registry_Username:
+        type: string
+      Override_Registry_Password:
+        type: string
+      Override_Registry_Namespace:
+        type: string
+      Override_Image_Tag:
+        type: string
+      Override_Dockerfile:
+        type: string
+      Override_Code_Path:
+        type: string
+      Use_Build_Cache:
+        type: boolean
+        default: true
+
+# Add in default values for the inputs plus define any missing variables we need.
+# Everything should take their values from env rather than inputs.
+env:
+  Registry_Base_URL: ${{ inputs.Override_Registry_Base_URL || vars.REGISTRY_BASE_URL }}
+# Registry_Username: This must be added in each job that needs it.
+# Registry_Password: This must be added in each job that needs it.
+  Registry_Namespace: ${{ inputs.Override_Registry_Namespace || vars.REGISTRY_NAMESPACE }}
+  Image_Tag: ${{ inputs.Override_Image_Tag || github.ref_name }}
+  Dockerfile: ${{ inputs.Override_Dockerfile || 'TurkeyDockerfile' }}
+  Code_Path: ${{ inputs.Override_Code_Path }}
+  Use_Build_Cache: ${{ inputs.Use_Build_Cache }}
+# repo_name: This must be added in each job that needs it.
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Env variables
+      - name: Assign username from secret
+        if: ${{ inputs.Override_Registry_Username == ''}}
+        run: |
+          echo "Registry_Username=${{ secrets.REGISTRY_USERNAME }}" >> "$GITHUB_ENV"
+
+      - name: Assign username from input
+        if: ${{ inputs.Override_Registry_Username != ''}}
+        run: |
+          USERNAME=$(jq -r '.inputs.Override_Registry_Username' $GITHUB_EVENT_PATH)
+          echo ::add-mask::$USERNAME
+          echo Registry_Username=$USERNAME >> $GITHUB_ENV
+
+      - name: Assign password from secret
+        if: ${{ inputs.Override_Registry_Password == ''}}
+        run: |
+          echo "Registry_Password=${{ secrets.REGISTRY_PASSWORD }}" >> "$GITHUB_ENV"
+
+      - name: Assign password from input
+        if: ${{ inputs.Override_Registry_Password != ''}}
+        run: |
+          PASSWORD=$(jq -r '.inputs.Override_Registry_Password' $GITHUB_EVENT_PATH)
+          echo ::add-mask::$PASSWORD
+          echo Registry_Password=$PASSWORD >> $GITHUB_ENV
+
+      - name: Add the repository name as an env variable # Lowercase is forced to prevent errors.
+        run: |
+          echo "repo_name=${GITHUB_REPOSITORY#*/}" | tr "[:upper:]" "[:lower:]" >> "$GITHUB_ENV"
+
+      # Code
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          path: "./repo"
+
+      - name: Use Code_Path for multirepo
+        if: ${{ env.Code_Path != ''}}
+        run: |
+          mkdir ./_repo
+          cp -rf ./repo/${{ env.Code_Path }}/* ./_repo
+          rm -rf ./repo
+          mv ./_repo ./repo
+          ls ./repo
+
+      # Docker
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          install: true
+
+      - name: Login to container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.Registry_Base_URL }}
+          username: ${{ env.Registry_Username }}
+          password: ${{ env.Registry_Password }}
+
+      - name: Docker Build and Push (with cache)
+        if: ${{ fromJSON(env.Use_Build_Cache) == true }}
+        uses: docker/build-push-action@v6
+        with:
+          context: repo/
+          file: repo/${{ env.Dockerfile }}
+          tags: ${{ env.Registry_Base_URL }}/${{ env.Registry_Namespace }}/${{ env.repo_name }}:${{ env.Image_Tag }}-latest,${{ env.Registry_Base_URL }}/${{ env.Registry_Namespace }}/${{ env.repo_name }}:${{ env.Image_Tag }}-${{ github.run_number }}
+          cache-from: type=registry,ref=${{ env.Registry_Base_URL }}/${{ env.Registry_Namespace }}/${{ env.repo_name }}:buildcache
+          cache-to: type=registry,ref=${{ env.Registry_Base_URL }}/${{ env.Registry_Namespace }}/${{ env.repo_name }}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true
+          push: true
+
+      - name: Docker Build and Push (no cache)
+        if: ${{ fromJSON(env.Use_Build_Cache) == false }}
+        uses: docker/build-push-action@v6
+        with:
+          context: repo/
+          file: repo/${{ env.Dockerfile }}
+          tags: ${{ env.Registry_Base_URL }}/${{ env.Registry_Namespace }}/${{ env.repo_name }}:${{ env.Image_Tag }}-latest,${{ env.Registry_Base_URL }}/${{ env.Registry_Namespace }}/${{ env.repo_name }}:${{ env.Image_Tag }}-${{ github.run_number }}
+          push: true


### PR DESCRIPTION
This allows docker images with a custom tag/name to be created on demand for any branch containing this workflow and pushed to the specified docker repository.  Two versions of the docker image will always be pushed, one ending with -latest and one ending with the workflow run number, e.g. my-custom-image-name-latest and my-custom-image-name-42.

The details required for the workflow to run can either be provided by predefined repository secrets/variables or specified manually when invoking the workflow.

This should help make it easier to customize Community Edition instances, test pull requests/development branches, and to provide docker images of long running branches (large alpha/beta features) for community testing.

The documentation for the workflow can be found in the hubs-docs repository:
https://github.com/Hubs-Foundation/hubs/wiki/GitHub-Workflows