### PR TITLE
Updates GitOps 

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -4,7 +4,7 @@ on: [push, workflow_dispatch]
 
 jobs:
   lint-and-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     services:
       postgres:
@@ -21,14 +21,14 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: '23.3'
+          otp-version: '24.2'
           elixir-version: '1.14'
 
-      - uses: actions/cache@v3.0.2
+      - uses: actions/cache@v4
         with:
           path: |
             deps


### PR DESCRIPTION
## What?
Updates Ubuntu for building to supported, and checkout action to current.



## Why?
The proximal cause was GitOps lint-and-test being blocked for building using an old version of Ubuntu.


## How to test
I. GitOps lint-and-test Action should fail only due to warnings being treated as errors
II. GitOps turkeyGitops Action should succeed (when running in the HubsFoundation repo)
III. hubs-compose with this should build and not have regressions
1. run the down script
2. cd to reticulum in hubs-compose
3. pull this branch
4. run `mix deps.get`
5. run the up script
6. if the reticulum container builds successfully, the Elixir automated tests have passed
7. smoke test Hubs

## Documentation of functionality
no changes

## Limitations
This PR doesn't update Elixir, which will need more testing.
