### PR TITLE
fixes bug: HTML for room generated even if scene is nil

### DIFF
--- a/lib/ret_web/templates/page/hub-meta.html.eex
+++ b/lib/ret_web/templates/page/hub-meta.html.eex
@@ -8,7 +8,7 @@
         "url": "<%= @hub |> Ret.Hub.url_for %>",
         "image": "<%= @hub |> Ret.Hub.image_url_for %>",
         "description": "<%= @description %>",
-        "disambiguatingDescription": "<%= @scene.name %>"
+        "disambiguatingDescription": "<%= @scene && @scene.name %>"
     }
 </script>
 


### PR DESCRIPTION
## What?
Checks that scene is truthy before extracting scene name for metadata

If the scene is falsy, this error arises:
```
key :name not found in: nil. If you are using the dot syntax, such as map.field, make sure the left-hand side of the dot is a map
```

## Why?
Apparantly, the scene can be nil, at least in hubs-compose, some of the time

Without this check, reticulum can't generate the HTML for the room

## How to test

1.     run the down script
2.     cd to reticulum in hubs-compose
3.     pull this branch
4.     run the up script
6.     open a Hubs room
7.     use the browser console to verify the JSON-LD metadata is there. `disambiguatingDescription` may be zero-length.

## Limitations
This PR doesn't update the lint-and-test GitOps


## Open questions
It's unclear if there's a more idiomatic way that works in an Elixir template

