### PR TITLE
turkeyGitops only run on push to master in Hubs-Foundation

### DIFF
--- a/.github/workflows/ret-turkey.yml
+++ b/.github/workflows/ret-turkey.yml
@@ -2,11 +2,14 @@ name: reticulum
 on:
   push:
     branches:
-    paths-ignore: ["README.md"]
+      - 'master'
+      - 'hotfix/**'
+    paths-ignore: [".github/**", "guides/**", "README.md", "LICENSE", "CODE_OF_CONDUCT.md"]
   workflow_dispatch:
 
 jobs:
   turkeyGitops:
+    if: github.repository_owner == 'Hubs-Foundation'
     uses: Hubs-Foundation/hubs-ops/.github/workflows/turkeyGitops.yml@master
     with:
       registry: hubsfoundation


### PR DESCRIPTION
## What?
Only builds images when the master branch on the Hubs-Foundatioin fork changes

## Why?
* avoids doomed attempts to run in forked repos
* avoids publishing from non-master branches

## How to test
1. push to master in forked repo
2. observe that action is kicked off, but job turkeyGitops doesn't run

3. push to non-master branch in original repo
4. observe that the action is not kicked off

## Documentation of functionality
Avoids failed runs; no new functionality
