### PR TITLE
Assembles informative & polished metadata from whatever values are available

### DIFF
--- a/lib/ret/http_utils.ex
+++ b/lib/ret/http_utils.ex
@@ -175,4 +175,20 @@ defmodule Ret.HttpUtils do
   defp module_config(key) do
     Application.get_env(:ret, __MODULE__)[key]
   end
+
+  def join_smart(enum) do
+    Enum.reduce(enum, "", fn(x, acc) ->
+      x = cond do
+        !x -> nil
+        is_binary(x) -> String.trim(x)
+        true -> "#{x}"
+      end
+      if x && x != "" do
+        if acc && acc != "", do: acc <> " — " <> x, else: x
+      else
+        acc
+      end
+    end)
+  end
+
 end

--- a/lib/ret_web/controllers/file_controller.ex
+++ b/lib/ret_web/controllers/file_controller.ex
@@ -26,8 +26,8 @@ defmodule RetWeb.FileController do
 
         app_name =
           AppConfig.get_cached_config_value("translations|en|app-full-name") ||
-            AppConfig.get_cached_config_value("translations|en|app-name")
-        title = "Photo taken in #{app_name} immersive space, powered by Hubs"
+            AppConfig.get_cached_config_value("translations|en|app-name") || RetWeb.Endpoint.host()
+        title = "Photo taken in #{app_name} immersive space"
         config = AppConfig.get_config()
 
         conn
@@ -36,7 +36,11 @@ defmodule RetWeb.FileController do
           content_type: content_type |> RetWeb.ContentType.sanitize_content_type(),
           content_length: content_length,
           title: title,
+          description_social_media: Ret.HttpUtils.join_smart([
+            config["translations"]["en"]["app-tagline"],
+            "powered by Hubs"]),
           translations: config["translations"]["en"],
+          app_name: app_name,
           images: config["images"],
           root_url: RetWeb.Endpoint.url()
         )

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -483,6 +483,12 @@ defmodule RetWeb.PageController do
 
     app_name = app_config["translations"]["en"]["app-name"] || RetWeb.Endpoint.host()
     scene = hub.scene || hub.scene_listing
+    name = cond do
+      hub.name && scene && scene.name && scene.name != hub.name -> join_smart([hub.name, scene.name])
+      hub.name -> hub.name
+      scene && scene.name -> scene.name
+      true -> "a room on " <> app_name
+    end
     hub_meta_tags =
       Phoenix.View.render_to_string(RetWeb.PageView, "hub-meta.html",
         hub: hub,
@@ -491,19 +497,16 @@ defmodule RetWeb.PageController do
         available_integrations_script: {:safe, available_integrations_script |> with_script_tags},
         translations: app_config["translations"]["en"],
         title: join_smart([hub.name, app_name]),
-        name: hub.name || scene.name || "a Hubs room",
+        name: name,
         description: join_smart([
           hub.description,
-          scene && scene.name,
           "an immersive space in #{app_name}, right in your browser",
           app_config["translations"]["en"]["app-description"],
           "powered by Hubs."
         ]) |> String.replace("\\n", " "),
         description_social_media: join_smart([
-          "Join others in an immersive space in #{app_name}",
+          "Join others in an immersive space in #{app_name}, right in your browser",
           hub.description,
-          scene && scene.name,
-          "right in your browser",
           app_config["translations"]["en"]["app-description"],
           "powered by Hubs."
         ]) |> String.replace("\\n", " "),

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -17,6 +17,7 @@ defmodule RetWeb.PageController do
 
   alias Plug.Conn
   import Ret.ConnUtils
+  import Ret.HttpUtils
 
   ##
   # NOTE: In addition to adding a route, you must add static html pages to the page_origin_warmer.ex
@@ -63,12 +64,19 @@ defmodule RetWeb.PageController do
   defp render_scene_content(%t{} = scene, conn) when t in [Scene, SceneListing] do
     {app_config, app_config_script} = generate_app_config()
 
+    app_name = app_config["translations"]["en"]["app-full-name"] || app_config["translations"]["en"]["app-name"] || RetWeb.Endpoint.host()
     scene_meta_tags =
       Phoenix.View.render_to_string(RetWeb.PageView, "scene-meta.html",
         scene: scene,
         ret_meta: Ret.Meta.get_meta(include_repo: false),
         translations: app_config["translations"]["en"],
-        description: "A scene you can use in the #{app_config["translations"]["en"]["app-name"] || ''} immersive spaces and others powered by Hubs. #{app_config["translations"]["en"]["app-description"] || ''}" |> String.replace("\\n", " "),
+        title: join_smart([ scene.name, app_name ]),
+        name: scene.name,
+        description: join_smart([
+          scene.description,
+          "A scene you can use in the #{app_name} immersive spaces and others powered by Hubs",
+          app_config["translations"]["en"]["app-description"]
+        ]) |> String.replace("\\n", " "),
         app_config_script: {:safe, app_config_script |> with_script_tags},
         extra_script: {:safe, get_extra_script(:scene) |> with_script_tags},
         extra_html: {:safe, get_extra_html(:scene) || ""}
@@ -97,10 +105,13 @@ defmodule RetWeb.PageController do
   defp render_avatar_content(%t{} = avatar, conn) when t in [Avatar, AvatarListing] do
     {app_config, app_config_script} = generate_app_config()
 
+    app_name = app_config["translations"]["en"]["app-full-name"] || app_config["translations"]["en"]["app-name"] || RetWeb.Endpoint.host()
     avatar_meta_tags =
       Phoenix.View.render_to_string(RetWeb.PageView, "avatar-meta.html",
         avatar: avatar,
-        description: "An avatar you can use in the #{app_config["translations"]["en"]["app-name"] || ""} immersive spaces and others powered by Hubs." |> String.replace("\\n", " "),
+        title: join_smart([avatar.name, app_name]),
+        name: avatar.name,
+        description: "An avatar you can use in the #{app_name} immersive spaces and others powered by Hubs.",
         ret_meta: Ret.Meta.get_meta(include_repo: false),
         translations: app_config["translations"]["en"],
         root_url: RetWeb.Endpoint.url(),
@@ -132,13 +143,20 @@ defmodule RetWeb.PageController do
   defp render_homepage_content(conn, nil = _public_room_id) do
     {app_config, app_config_script} = generate_app_config()
 
+    app_name = app_config["translations"]["en"]["app-full-name"] || app_config["translations"]["en"]["app-name"] || RetWeb.Endpoint.host()
+
     index_meta_tags =
       Phoenix.View.render_to_string(
         RetWeb.PageView,
         "index-meta.html",
         root_url: RetWeb.Endpoint.url(),
         translations: app_config["translations"]["en"],
-        description: "#{app_config["translations"]["en"]["app-description"] || ''} — Immersive spaces, right in your browser, powered by Hubs" |> String.replace("\\n", " "),
+        app_name: app_name,
+        title: join_smart([app_name, app_config["translations"]["en"]["app-tagline"]]),
+        description: join_smart(
+          [app_config["translations"]["en"]["app-description"],
+          "Immersive spaces, right in your browser, powered by Hubs"
+        ]),
         images: app_config["images"],
         app_config_script: {:safe, app_config_script |> with_script_tags},
         extra_script: {:safe, get_extra_script(:index) |> with_script_tags},
@@ -272,10 +290,11 @@ defmodule RetWeb.PageController do
             manifest =
               Phoenix.View.render_to_string(RetWeb.PageView, "manifest.webmanifest",
                 root_url: RetWeb.Endpoint.url(),
-                app_name: get_app_config_value("translations|en|app-name") || "",
-                app_description:
-                  (get_app_config_value("translations|en|app-description") || "")
-                  |> String.replace("\\n", " ")
+                app_name: get_app_config_value("translations|en|app-name") || RetWeb.Endpoint.host(),
+                app_description: join_smart([
+                  get_app_config_value("translations|en|app-description"),
+                  "Immersive spaces, right in your browser, powered by Hubs"
+                ]) |> String.replace("\\n", " ")
               )
 
             unless module_config(:skip_cache) do
@@ -394,7 +413,7 @@ defmodule RetWeb.PageController do
     |> put_resp_header(
       "hub-name",
       get_app_config_value("translations|en|app-full-name") ||
-        get_app_config_value("translations|en|app-name") || ""
+        get_app_config_value("translations|en|app-name") || RetWeb.Endpoint.host()
     )
     |> put_resp_header(
       "hub-entity-type",
@@ -462,14 +481,32 @@ defmodule RetWeb.PageController do
     {_, available_integrations_script} =
       Ret.Meta.available_integrations_meta() |> generate_config("AVAILABLE_INTEGRATIONS")
 
+    app_name = app_config["translations"]["en"]["app-name"] || RetWeb.Endpoint.host()
+    scene = hub.scene || hub.scene_listing
     hub_meta_tags =
       Phoenix.View.render_to_string(RetWeb.PageView, "hub-meta.html",
         hub: hub,
-        scene: hub.scene,
+        scene: scene,
         ret_meta: Ret.Meta.get_meta(include_repo: false),
         available_integrations_script: {:safe, available_integrations_script |> with_script_tags},
         translations: app_config["translations"]["en"],
-        description: "Join others in an immersive space in #{app_config["translations"]["en"]["app-name"] || ''}, right in your browser. #{app_config["translations"]["en"]["app-description"] || ''} — Powered by Hubs." |> String.replace("\\n", " "),
+        title: join_smart([hub.name, app_name]),
+        name: hub.name || scene.name || "a Hubs room",
+        description: join_smart([
+          hub.description,
+          scene && scene.name,
+          "an immersive space in #{app_name}, right in your browser",
+          app_config["translations"]["en"]["app-description"],
+          "powered by Hubs."
+        ]) |> String.replace("\\n", " "),
+        description_social_media: join_smart([
+          "Join others in an immersive space in #{app_name}",
+          hub.description,
+          scene && scene.name,
+          "right in your browser",
+          app_config["translations"]["en"]["app-description"],
+          "powered by Hubs."
+        ]) |> String.replace("\\n", " "),
         app_config_script: {:safe, app_config_script |> with_script_tags},
         extra_script: {:safe, get_extra_script(:room) |> with_script_tags},
         extra_html: {:safe, get_extra_html(:room) || ""}

--- a/lib/ret_web/email.ex
+++ b/lib/ret_web/email.ex
@@ -3,7 +3,7 @@ defmodule RetWeb.Email do
   alias Ret.{AppConfig}
 
   def auth_email(to_address, signin_args) do
-    app_name = AppConfig.get_cached_config_value("translations|en|app-name")
+    app_name = AppConfig.get_cached_config_value("translations|en|app-name") || RetWeb.Endpoint.host()
     app_full_name = AppConfig.get_cached_config_value("translations|en|app-full-name") || app_name
     admin_email = Application.get_env(:ret, Ret.Account)[:admin_email]
     custom_login_subject = AppConfig.get_cached_config_value("auth|login_subject")

--- a/lib/ret_web/templates/file/show.html.eex
+++ b/lib/ret_web/templates/file/show.html.eex
@@ -13,30 +13,34 @@
         "contentUrl": "<%= @image_url %>",
         "encodingFormat": "<%= @content_type %>",
         "contentSize": "<%= @content_length %> b",
-        "keywords": ["screenshot", "Hubs", "immersive 3D spaces", "social VR", "<%= @translations["share-hashtag"] %>"],
+        "keywords": ["screenshot", "Hubs", "immersive 3D spaces", "social VR", "<%= @translations["share-hashtag"] %>", "<%= @translations["company-name"] %>"],
+        <%= if @translations["company-name"] || @translations["contact-email"] do %>
         "maintainer": {
             "@type": "Organization",
-            "name": "<%= @translations["company-name"] %>",
+            "name": "<%= @translations["company-name"] || @app_name %>",
             "email": "<%= @translations["contact-email"] %>",
             "logo": "<%= @images["company_logo"] %>"
         },
+        <% end %>
         "isBasedOn": "<%= @root_url %>/",
-        "creditText": "check with <%= @translations["company-name"] %>"
+        "creditText": "check with <%= @translations["company-name"] || @app_name %>"
     }
     </script>
 
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:domain" value="<%= RetWeb.Endpoint.host %>" />
     <meta name="twitter:title" value="<%= @title %>" />
-    <meta name="twitter:description" content="<%= @title %>">
+    <meta name="twitter:description" content="<%= @description_social_media %>">
     <meta name="twitter:image" content="<%= @image_url %>"/>
     <meta name="twitter:url" value="<%= @image_url %>" />
 
     <meta property="og:type" content="website" />
     <meta property="og:url" content="<%= @image_url %>" />
     <meta property="og:title" content="<%= @title %>" />
-    <meta property="og:description" content="<%= @title %>">
+    <meta name="description" property="og:description" content="<%= @description_social_media %>">
     <meta property="og:image" content="<%= @image_url %>"/>
+    <meta property="og:image:type" content="<%= @content_type %>" />
+    <meta name="application-name" property="og:site_name" content="<%= @app_name %>" />
     <title><%= @title %></title>
     <style>
       body {
@@ -58,7 +62,7 @@
   </head>
   <body>
     <a href="<%= RetWeb.Endpoint.url %>">
-        <img src="<%= @image_url %>"/>
+        <img src="<%= @image_url %>" alt="<%= @title %>"/>
     </a>
   </body>
 </html>

--- a/lib/ret_web/templates/page/avatar-meta.html.eex
+++ b/lib/ret_web/templates/page/avatar-meta.html.eex
@@ -2,12 +2,12 @@
     {
         "@context": "https://schema.org/",
         "@type": "3DModel",
-        "name": "<%= @avatar.name %> | <%= @translations["app-full-name"] || @translations["app-name"] %>",
+        "name": "<%= @name %>",
         "url": "<%= @avatar |> Ret.Avatar.url %>",
         "contentUrl": "<%= @avatar.gltf_owned_file |> Ret.OwnedFile.uri_for |> URI.to_string %>",
         "thumbnailUrl": "<%= @avatar.thumbnail_owned_file |> Ret.OwnedFile.uri_for |> URI.to_string %>",
         "description": "<%= @description %>",
-        "isResizable": false,
+        "isResizable": true,
         "keywords": ["3D avatar", "Hubs", "immersive 3D spaces", "social VR", "<%= @translations["share-hashtag"] %>"],
         "isPartOf": "<%= @root_url %>/"
     }
@@ -15,14 +15,14 @@
 
 <meta property="og:type" content="website" />
 <meta property="og:url" content="<%= @avatar |> Ret.Avatar.url %>" />
-<meta property="og:title" content="<%= @avatar.name %> | <%= @translations["app-full-name"] || @translations["app-name"] %>" />
-<meta property="og:description" content="<%= @description %>" />
+<meta property="og:title" content="<%= @name %>" />
+<meta name="description" property="og:description" content="<%= @description %>" />
 <meta property="og:image" content="<%= @avatar.thumbnail_owned_file |> Ret.OwnedFile.uri_for |> URI.to_string %>"/>
-<meta property="og:site_name" content="<%= @translations["app-full-name"] || @translations["app-name"] %>"/>
+<meta name="application-name" property="og:site_name" content="<%= @translations["app-full-name"] || @translations["app-name"] || RetWeb.Endpoint.host() %>"/>
 
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:domain" content="<%= RetWeb.Endpoint.host %>" />
-<meta name="twitter:title" content="<%= @avatar.name %> | <%= @translations["app-full-name"] || @translations["app-name"] %>" />
+<meta name="twitter:title" content="<%= @name %>" />
 <meta name="twitter:description" content="<%= @description %>" />
 <meta name="twitter:image" content="<%= @avatar.thumbnail_owned_file |> Ret.OwnedFile.uri_for |> URI.to_string %>"/>
 <meta name="twitter:url" content="<%= @avatar |> Ret.Avatar.url %>" />
@@ -32,8 +32,7 @@
 <meta name="ret:phx_port" value="<%= @ret_meta[:phx_port] %>" />
 <meta name="ret:pool" value="<%= @ret_meta[:pool] %>" />
 
-<title><%= @avatar.name %> | <%= @translations["app-full-name"] || @translations["app-name"] %></title>
-<meta name="description" content="<%= @description %>" />
+<title><%= @title %></title>
 
 <%= @app_config_script %>
 <%= @extra_html %>

--- a/lib/ret_web/templates/page/hub-meta.html.eex
+++ b/lib/ret_web/templates/page/hub-meta.html.eex
@@ -4,30 +4,24 @@
     {
         "@context": "https://schema.org/",
         "@type": "VirtualLocation",
-        "name": "<%= @hub.name %> | <%= @translations["app-full-name"] || @translations["app-name"] || "" %>",
+        "name": "<%= @name %>",
         "url": "<%= @hub |> Ret.Hub.url_for %>",
         "image": "<%= @hub |> Ret.Hub.image_url_for %>",
-        "description": "<%= @description %>",
-        "disambiguatingDescription": "<%= @scene && @scene.name %>"
+        "description": "<%= @description %>"
     }
 </script>
 
 <meta property="og:type" content="website" />
 <meta property="og:url" content="<%= @hub |> Ret.Hub.url_for %>" />
-<meta property="og:title" content="<%= @hub.name %> | <%= @translations["app-full-name"] || @translations["app-name"] %>" />
-<meta property="og:description" content="<%= @description %>" />
+<meta property="og:title" content="<%= @name %>" />
+<meta name="description" property="og:description" content="<%= @description_social_media %>" />
 <meta property="og:image" content="<%= @hub |> Ret.Hub.image_url_for %>"/>
-<meta property="og:site_name" content="<%= @translations["app-full-name"] || @translations["app-name"] %>"/>
-
-<meta name="description" content="<%= @description %>" />
-
-<meta itemprop="name" content="<%= @hub.name %> | <%= @translations["app-full-name"] || @translations["app-name"] %>" />
-<meta itemprop="description" content="<%= @description %>" />
+<meta name="application-name" property="og:site_name" content="<%= @translations["app-full-name"] || @translations["app-name"] || RetWeb.Endpoint.host() %>"/>
 
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:domain" content="<%= RetWeb.Endpoint.host %>" />
-<meta name="twitter:title" content="<%= @hub.name %> | <%= @translations["app-full-name"] || @translations["app-name"] %>" />
-<meta name="twitter:description" content="<%= @description %>" />
+<meta name="twitter:title" content="<%= @name %>" />
+<meta name="twitter:description" content="<%= @description_social_media %>" />
 <meta name="twitter:image" content="<%= @hub |> Ret.Hub.image_url_for %>"/>
 <meta name="twitter:url" content="<%= @hub |> Ret.Hub.url_for %>" />
 
@@ -38,7 +32,7 @@
 
 <link rel="apple-touch-icon" href="/app-icon.png">
 
-<title><%= @hub.name %> | <%= @translations["app-full-name"] || @translations["app-name"] %></title>
+<title><%= @title %></title>
 
 <%= @available_integrations_script %>
 <%= @app_config_script %>

--- a/lib/ret_web/templates/page/hub.service-meta.js.eex
+++ b/lib/ret_web/templates/page/hub.service-meta.js.eex
@@ -1,1 +1,1 @@
-appFullName = "<%= @translations["app-full-name"] || @translations["app-name"] %>";
+appFullName = "<%= @translations["app-full-name"] || @translations["app-name"] || RetWeb.Endpoint.host() %>";

--- a/lib/ret_web/templates/page/index-meta.html.eex
+++ b/lib/ret_web/templates/page/index-meta.html.eex
@@ -1,9 +1,6 @@
 <!-- iOS (for "Add to Homescreen") -->
 <meta name="mobile-web-app-capable" content="yes">
 
-<!-- Description for search engines -->
-<meta name="description" content="<%= @description %>">
-
 <!-- Schema.org for Google -->
 <script type="application/ld+json">
     {
@@ -11,29 +8,43 @@
         "@type": "WebApplication",
         "browserRequirements": "WebGL",
         "applicationCategory": ["MultimediaApplication", "CommunicationApplication", "SocialNetworkingApplication"],
-        "name": "<%= @translations["app-full-name"] || @translations["app-name"] %>",
+        "name": "<%= @app_name %>",
         "url": "<%= @root_url %>",
         "description": "<%= @description %>",
+        <%= if @translations["app-tagline"] do %>
         "headline": "<%= @translations["app-tagline"] %>",
+        <% end %>
         "keywords": ["Hubs", "immersive 3D spaces", "social VR", "<%= @translations["share-hashtag"] %>"],
+        <%= if @images["home_background"] do %>
         "image": "<%= @images["home_background"] %>",
+        <% end %>
+        <%= if  @images["logo"] do %>
         "thumbnailUrl": "<%= @images["logo"] %>",
+        <% end %>
+        <%= if @translations["company-name"] || @translations["contact-email"] do %>
         "maintainer": {
             "@type": "Organization",
-            "name": "<%= @translations["company-name"] %>",
+            "name": "<%= @translations["company-name"] || @app_name %>",
+            <%= if @translations["contact-email"] do %>
             "email": "<%= @translations["contact-email"] %>",
+            <% end %>
+            <%= if @images["company_logo"] do %>
             "logo": "<%= @images["company_logo"] %>"
+            <% end %>
         },
+        <% end %>
         "operatingSystem": "Web Platform"
     }
 </script>
 
 <!-- OpenGraph for Facebook -->
 <meta property="og:type" content="website">
-<meta property="og:title" content="<%= @translations["app-full-name"] || @translations["app-name"] %>"/>
-<meta property="og:description" content="<%= @description %>">
+<meta property="og:title" content="<%= @app_name %>"/>
+<meta name="description" property="og:description" content="<%= @description %>">
 <meta property="og:url" content="/">
+<%= if @images["home_background"] do %>
 <meta property="og:image" content="<%= @images["home_background"] %>">
+<% end %>
 
 <!-- Twitter -->
 <meta name="twitter:card" content="summary_large_image">
@@ -42,17 +53,20 @@
 <meta name="twitter:site" content="<%= @translations["app-twitter-user"] %>">
 <% end %>
 
-<meta name="twitter:title" content="<%= @translations["app-full-name"] || @translations["app-name"] %>">
+<meta name="twitter:title" content="<%= @app_name %>">
+<%= if @images["home_background"] do %>
 <meta name="twitter:image" content="<%= @images["home_background"] %>">
+<% end %>
 <meta name="twitter:description" content="<%= @description %>">
 
 <!-- Microsoft Edge -->
-<meta name="application-name" content="<%= @translations["app-full-name"] || @translations["app-name"] %>">
+<meta name="application-name" property="og:site_name" content="<%= @app_name %>">
+<meta name="creator" content="<%= @translations["company-name"] || @app_name %>" >
 <meta name="msapplication-tooltip" content="<%= @translations["app-tagline"] %>">
 <meta name="msapplication-starturl" content="/">
 <link rel="apple-touch-icon" href="/app-icon.png">
 
-<title><%= @translations["app-name"] %> - <%= @translations["app-tagline"] %></title>
+<title><%= @title %></title>
 <%= @app_config_script %>
 <%= @extra_html %>
 <%= @extra_script %>

--- a/lib/ret_web/templates/page/link-meta.html.eex
+++ b/lib/ret_web/templates/page/link-meta.html.eex
@@ -1,1 +1,1 @@
-<title>Enter Code | <%= @translations["app-full-name"] || @translations["app-name"] %></title>
+<title>Enter Code | <%= @translations["app-full-name"] || @translations["app-name"] || RetWeb.Endpoint.host() %></title>

--- a/lib/ret_web/templates/page/scene-meta.html.eex
+++ b/lib/ret_web/templates/page/scene-meta.html.eex
@@ -5,7 +5,7 @@
     {
         "@context": "https://schema.org/",
         "@type": "VirtualLocation",
-        "name": "<%= @scene.name %> | <%= @translations["app-full-name"] || @translations["app-name"] || "" %>",
+        "name": "<%= @name %>",
         "url": "<%= @scene |> Ret.Scene.to_url %>",
         "image": "<%= @scene.screenshot_owned_file |> Ret.OwnedFile.uri_for |> URI.to_string %>",
         "description": "<%= @description %>"
@@ -14,19 +14,14 @@
 
 <meta property="og:type" content="website" />
 <meta property="og:url" content="<%= @scene |> Ret.Scene.to_url %>" />
-<meta property="og:title" content="<%= @scene.name %> | <%= @translations["app-full-name"] || @translations["app-name"] %>" />
-<meta property="og:description" content="<%= @description %>" />
+<meta property="og:title" content="<%= @name %>" />
+<meta name="description" property="og:description" content="<%= @description %>" />
 <meta property="og:image" content="<%= @scene.screenshot_owned_file |> Ret.OwnedFile.uri_for |> URI.to_string %>"/>
-<meta property="og:site_name" content="<%= @translations["app-full-name"] || @translations["app-name"] %>"/>
-
-<meta name="description" content="<%= @description %>" />
-
-<meta itemprop="name" content="<%= @scene.name %> | <%= @translations["app-full-name"] || @translations["app-name"] %>" />
-<meta itemprop="description" content="<%= @description %>" />
+<meta name="application-name" property="og:site_name" content="<%= @translations["app-full-name"] || @translations["app-name"] || RetWeb.Endpoint.host() %>"/>
 
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:domain" content="<%= RetWeb.Endpoint.host %>" />
-<meta name="twitter:title" content="<%= @scene.name %> | <%= @translations["app-full-name"] || @translations["app-name"] %>" />
+<meta name="twitter:title" content="<%= @name %>" />
 <meta name="twitter:description" content="<%= @description %>" />
 <meta name="twitter:image" content="<%= @scene.screenshot_owned_file |> Ret.OwnedFile.uri_for |> URI.to_string %>"/>
 <meta name="twitter:url" content="<%= @scene |> Ret.Scene.to_url %>" />
@@ -36,7 +31,7 @@
 <meta name="ret:phx_port" value="<%= @ret_meta[:phx_port] %>" />
 <meta name="ret:pool" value="<%= @ret_meta[:pool] %>" />
 
-<title><%= @scene.name %> | <%= @translations["app-full-name"] || @translations["app-name"] %></title>
+<title><%= @title %></title>
 <%= @app_config_script %>
 <%= @extra_html %>
 <%= @extra_script %>

--- a/lib/ret_web/templates/page/whats-new-meta.html.eex
+++ b/lib/ret_web/templates/page/whats-new-meta.html.eex
@@ -1,1 +1,1 @@
-<title>What's New | <%= @translations["app-full-name"] || @translations["app-name"] %></title>
+<title>What's New | <%= @translations["app-full-name"] || @translations["app-name"] || RetWeb.Endpoint.host() %></title>


### PR DESCRIPTION
## What?
Provides default values and fallback values when admin hasn't set an App Setting or the code doesn't currently supply it.
Assembles the available values so there are no unprofessional-looking gaps.
* For a room, if scene is nil, uses scenelist
* Provides context text, so social media previews are actionable
* If App Name is nil, uses hostname
* if Company Name is blank, uses App Name
* forms descriptions using all relevant values, eliminating nils and concatenating values using em-dashes


## Why?
Admins don't necessarily set all the App Settings.
There are bugs, such as the scene being unavailable for some rooms.
Metadata such as titles and descriptions is often the first contact a user has with an instance. If they contain obvious gaps, the instance looks amateurish.


## Examples
<img width="371" alt="image" src="https://github.com/user-attachments/assets/e86e6428-fbae-482f-8faa-aadd89ae00f0" />


## How to test
1. Pull this branch into Hubs Compose
2. Run `bin up`
3. Navigate to root page, a room, a screenshot, a scene, and an avatar. For each, copy the HEAD tag as a snippet to https://validator.schema.org
4. Configure a public instance to pull reticulum Always, and from dougreeder/reticulumbeta:v1
5. Temporarily delete all values from the App Settings in the Admin Panel
6. Navigate to root page, a room, a screenshot, a scene, and an avatar. For each, paste the URL to https://www.opengraph.xyz and observe the previews
7. Restore values in the App Settings
8. Repeat step 6 and observe the expanded metadata


## Documentation of functionality
https://schema.org/VirtualLocation etc.
https://ogp.me/

## Limitations
There are values that Hubs doesn't currently record, so far as I know, such as which user took a screenshot, what room it was, and what scene.  Saving those values in the database and retrieving them would be non-trivial.
