### PR TITLE
Update Discord API to v10

### DIFF
--- a/lib/ret/discord_client.ex
+++ b/lib/ret/discord_client.ex
@@ -3,7 +3,7 @@ defmodule Ret.DiscordClient do
   import Bitwise
 
   @oauth_scope "identify email"
-  @discord_api_base "https://discordapp.com/api/v6"
+  @discord_api_base "https://discord.com/api/v10"
 
   def get_oauth_url(hub_sid) do
     authorize_params = %{
@@ -91,7 +91,7 @@ defmodule Ret.DiscordClient do
       }) do
     case Cachex.fetch(:discord_api, "/users/#{provider_account_id}") do
       {status, result} when status in [:commit, :ok] ->
-        "#{result["username"]}##{result["discriminator"]}"
+        "#{result["username"]}"
     end
   end
 
@@ -161,13 +161,18 @@ defmodule Ret.DiscordClient do
         case Cachex.fetch(:discord_api, "/guilds/#{community_id}/roles") do
           {status, result} when status in [:commit, :ok] -> result |> Map.new(&{&1["id"], &1})
         end
+        # Note: Whether the bitfield values in guild_roles are represented as strings or integers is inconsistent (possibly based on what permissions the user has), so every time they're used they need to be checked and, if needed, converted to integers.
 
       role_everyone = guild_roles[community_id]
       permissions = role_everyone["permissions"]
 
       user_permissions = user_roles |> Enum.map(&guild_roles[&1]["permissions"])
 
-      permissions = user_permissions |> Enum.reduce(permissions, &(&1 ||| &2))
+      permissions = user_permissions |>
+      Enum.reduce(permissions, &(
+      if is_binary(&1), do: String.to_integer(&1), else: &1 |||
+      if is_binary(&2), do: String.to_integer(&2), else: &2
+      ))
 
       if (permissions &&& @administrator) == @administrator do
         @all
@@ -190,12 +195,15 @@ defmodule Ret.DiscordClient do
             |> Map.get("permission_overwrites")
             |> Map.new(&{&1["id"], &1})
         end
+        # Note: Whether the bitfield values in channel_overwrites are represented as strings or integers is inconsistent (possibly based on what permissions the user has), so every time they're used they need to be checked and, if needed, converted to integers.
 
       overwrite_everyone = channel_overwrites[community_id]
 
       permissions =
         if overwrite_everyone do
-          (permissions &&& ~~~overwrite_everyone["deny"]) ||| overwrite_everyone["allow"]
+          (permissions &&&
+          ~~~if is_binary(overwrite_everyone["deny"]), do: String.to_integer(overwrite_everyone["deny"]), else: overwrite_everyone["deny"]) |||
+          if is_binary(overwrite_everyone["allow"]), do: String.to_integer(overwrite_everyone["allow"]), else: overwrite_everyone["allow"]
         else
           permissions
         end
@@ -204,8 +212,14 @@ defmodule Ret.DiscordClient do
       user_permissions =
         user_roles |> Enum.map(&channel_overwrites[&1]) |> Enum.filter(&(&1 != nil))
 
-      allow = user_permissions |> Enum.reduce(@none, &(&1["allow"] ||| &2))
-      deny = user_permissions |> Enum.reduce(@none, &(&1["deny"] ||| &2))
+      allow = user_permissions |> Enum.reduce(@none, &(
+      if is_binary(&1["allow"]), do: String.to_integer(&1["allow"]), else: &1["allow"] |||
+      &2
+      ))
+      deny = user_permissions |> Enum.reduce(@none, &(
+      if is_binary(&1["deny"]), do: String.to_integer(&1["deny"]), else: &1["deny"] |||
+      &2
+      ))
 
       permissions = (permissions &&& ~~~deny) ||| allow
 
@@ -214,7 +228,9 @@ defmodule Ret.DiscordClient do
 
       permissions =
         if overwrite_member do
-          (permissions &&& ~~~overwrite_member["deny"]) ||| overwrite_member["allow"]
+          (permissions &&&
+          ~~~if is_binary(overwrite_member["deny"]), do: String.to_integer(overwrite_member["deny"]), else: overwrite_member["deny"]) |||
+          if is_binary(overwrite_member["allow"]), do: String.to_integer(overwrite_member["allow"]), else: overwrite_member["allow"]
         else
           permissions
         end


### PR DESCRIPTION
## What?
<!-- REQUIRED — Explain what your pull request does -->
Updates the Discord client to use version 10 of the Discord API and account for its quirks/changes.

## Why?
<!-- REQUIRED — Explain why you're opening this pull request, what limitations does it address, etc..  If you're fixing a bug with an open bug report you can just link to the bug report -->
The version of the Discord API was very old and will likely stop working in the near future.  Plus it's good to do as general maintenance.

## Examples
<!-- If applicable, give examples of your changes, screenshots, videos, etc. -->
N/A

## How to test
<!-- REQUIRED — Give the steps required to test your pull request -->

1. Redeploy your instance using a Reticulum image generated from this PR (e.g. `ghcr.io/exairnous/reticulum:update-discord-api-to-v10-36`). 
2. Log out of the instance the Hubs bot is connected to.
3. Join a room created by the Hubs bot.
4. See that you can't join without being logged into Discord and having permission to view the channel that the room is bridged to.
5. See that your username is set/restricted to your Discord username or per-server nickname.
6. See that the permissions you've been granted are based on your permissions in Discord.

## Documentation of functionality
<!-- REQUIRED — Link to the accompanying documentation pull request or identify where the documentation is located in this pull request.  If no documentation is needed, please specify this here -->
No functionality should have changed, so there is no need for documentation to be updated.

## Limitations
<!-- List anything that isn't addressed, e.g. corner cases, and why they weren't addressed -->
None.

## Alternatives considered
<!-- If there are any alternative ways of implementing this that you thought of, but decided against, list them here along with why they were discarded -->
None.

## Open questions
<!-- List any questions you have -->
None.

## Additional details or related context
<!-- Give any other details that you think the reviewers should be aware of -->
Discord seems to waffle between sending us integers and strings for permissions bitfield values depending on what permission level you are (e.g. users with room owner permissions seemed to have integers sent, but non-privileged users seemed to have strings sent), so this had to be accounted for by testing whether the value was a string or not and converting any strings to integers.

Discord has changed and usernames for people are now enforced to be unique and the discriminator numbers aren't appended to the end anymore (Discord bots still use discriminators, but this isn't relevant to us).
https://discord.fandom.com/wiki/Discriminator

Companion PR to https://github.com/Hubs-Foundation/hubs-discord-bot/pull/145 (although they should be able to be applied independently of each other).
