### PR TITLE
Check for the global name if the per-server nickname isn't present

### DIFF
--- a/lib/ret/discord_client.ex
+++ b/lib/ret/discord_client.ex
@@ -3,7 +3,7 @@ defmodule Ret.DiscordClient do
   import Bitwise
 
   @oauth_scope "identify email"
-  @discord_api_base "https://discordapp.com/api/v6"
+  @discord_api_base "https://discord.com/api/v10"
 
   def get_oauth_url(hub_sid) do
     authorize_params = %{
@@ -91,7 +91,7 @@ defmodule Ret.DiscordClient do
       }) do
     case Cachex.fetch(:discord_api, "/users/#{provider_account_id}") do
       {status, result} when status in [:commit, :ok] ->
-        "#{result["username"]}##{result["discriminator"]}"
+        "#{result["username"]}"
     end
   end
 
@@ -161,13 +161,18 @@ defmodule Ret.DiscordClient do
         case Cachex.fetch(:discord_api, "/guilds/#{community_id}/roles") do
           {status, result} when status in [:commit, :ok] -> result |> Map.new(&{&1["id"], &1})
         end
+        # Note: Whether the bitfield values in guild_roles are represented as strings or integers is inconsistent (possibly based on what permissions the user has), so every time they're used they need to be checked and, if needed, converted to integers.
 
       role_everyone = guild_roles[community_id]
       permissions = role_everyone["permissions"]
 
       user_permissions = user_roles |> Enum.map(&guild_roles[&1]["permissions"])
 
-      permissions = user_permissions |> Enum.reduce(permissions, &(&1 ||| &2))
+      permissions = user_permissions |>
+      Enum.reduce(permissions, &(
+      if is_binary(&1), do: String.to_integer(&1), else: &1 |||
+      if is_binary(&2), do: String.to_integer(&2), else: &2
+      ))
 
       if (permissions &&& @administrator) == @administrator do
         @all
@@ -190,12 +195,15 @@ defmodule Ret.DiscordClient do
             |> Map.get("permission_overwrites")
             |> Map.new(&{&1["id"], &1})
         end
+        # Note: Whether the bitfield values in channel_overwrites are represented as strings or integers is inconsistent (possibly based on what permissions the user has), so every time they're used they need to be checked and, if needed, converted to integers.
 
       overwrite_everyone = channel_overwrites[community_id]
 
       permissions =
         if overwrite_everyone do
-          (permissions &&& ~~~overwrite_everyone["deny"]) ||| overwrite_everyone["allow"]
+          (permissions &&&
+          ~~~if is_binary(overwrite_everyone["deny"]), do: String.to_integer(overwrite_everyone["deny"]), else: overwrite_everyone["deny"]) |||
+          if is_binary(overwrite_everyone["allow"]), do: String.to_integer(overwrite_everyone["allow"]), else: overwrite_everyone["allow"]
         else
           permissions
         end
@@ -204,8 +212,14 @@ defmodule Ret.DiscordClient do
       user_permissions =
         user_roles |> Enum.map(&channel_overwrites[&1]) |> Enum.filter(&(&1 != nil))
 
-      allow = user_permissions |> Enum.reduce(@none, &(&1["allow"] ||| &2))
-      deny = user_permissions |> Enum.reduce(@none, &(&1["deny"] ||| &2))
+      allow = user_permissions |> Enum.reduce(@none, &(
+      if is_binary(&1["allow"]), do: String.to_integer(&1["allow"]), else: &1["allow"] |||
+      &2
+      ))
+      deny = user_permissions |> Enum.reduce(@none, &(
+      if is_binary(&1["deny"]), do: String.to_integer(&1["deny"]), else: &1["deny"] |||
+      &2
+      ))
 
       permissions = (permissions &&& ~~~deny) ||| allow
 
@@ -214,7 +228,9 @@ defmodule Ret.DiscordClient do
 
       permissions =
         if overwrite_member do
-          (permissions &&& ~~~overwrite_member["deny"]) ||| overwrite_member["allow"]
+          (permissions &&&
+          ~~~if is_binary(overwrite_member["deny"]), do: String.to_integer(overwrite_member["deny"]), else: overwrite_member["deny"]) |||
+          if is_binary(overwrite_member["allow"]), do: String.to_integer(overwrite_member["allow"]), else: overwrite_member["allow"]
         else
           permissions
         end

--- a/lib/ret/discord_client.ex
+++ b/lib/ret/discord_client.ex
@@ -76,12 +76,20 @@ defmodule Ret.DiscordClient do
         {status, result} when status in [:commit, :ok] -> "#{result["nick"]}"
       end
 
-    if nickname == "" do
+    nickname = if nickname == "" do
+       case Cachex.fetch(:discord_api, "/users/#{provider_account_id}") do
+        {status, result} when status in [:commit, :ok] -> "#{result["global_name"]}"
+      end
+      else
+        nickname
+    end
+
+    nickname = if nickname == "" do
       case Cachex.fetch(:discord_api, "/users/#{provider_account_id}") do
         {status, result} when status in [:commit, :ok] -> "#{result["username"]}"
       end
-    else
-      nickname
+      else
+        nickname
     end
   end
 

--- a/lib/ret/discord_client.ex
+++ b/lib/ret/discord_client.ex
@@ -76,7 +76,7 @@ defmodule Ret.DiscordClient do
         {status, result} when status in [:commit, :ok] -> "#{result["nick"]}"
       end
 
-    nickname = if nickname == "" do
+    nickname = if !nickname or nickname == "" do
        case Cachex.fetch(:discord_api, "/users/#{provider_account_id}") do
         {status, result} when status in [:commit, :ok] -> "#{result["global_name"]}"
       end
@@ -84,7 +84,7 @@ defmodule Ret.DiscordClient do
         nickname
     end
 
-    nickname = if nickname == "" do
+    nickname = if !nickname or nickname == "" do
       case Cachex.fetch(:discord_api, "/users/#{provider_account_id}") do
         {status, result} when status in [:commit, :ok] -> "#{result["username"]}"
       end


### PR DESCRIPTION
## What?
<!-- REQUIRED — Explain what your pull request does -->
If no per-server nickname has been set, this checks to see if Discord's global name is set for the user before falling back to the username.

## Why?
<!-- REQUIRED — Explain why you're opening this pull request, what limitations does it address, etc..  If you're fixing a bug with an open bug report you can just link to the bug report -->
This makes the name used in Hubs match what Discord displays in the Discord server instead of predominantly using their (usually less aesthetically pleasing) username.

## Examples
<!-- If applicable, give examples of your changes, screenshots, videos, etc. -->
N/A

## How to test
<!-- REQUIRED — Give the steps required to test your pull request -->

1. Redeploy your instance using a Reticulum image generated from this PR (e.g. `ghcr.io/exairnous/reticulum:use-discord-display-names-37`). 
2. Follow the instructions for hacking on the bot locally that are listed in PR https://github.com/Hubs-Foundation/hubs-discord-bot/pull/146 and set up the Hubs bot against your Community Edition instance.
3. Create a room with the Hubs bot with `!hubs create`.
4. Join the room created by the Hubs bot.
5. See that your username is set/restricted to your Discord display name or per-server nickname.

## Documentation of functionality
<!-- REQUIRED — Link to the accompanying documentation pull request or identify where the documentation is located in this pull request.  If no documentation is needed, please specify this here -->
This is an implementation detail and doesn't need to be documented.  It is also immediately obvious.

## Limitations
<!-- List anything that isn't addressed, e.g. corner cases, and why they weren't addressed -->
If two Discord accounts join with matching names there is pretty much no way to tell them apart without the username being included.  However, this isn't any different than two people in a non Discord bot created room setting their names to be the same.

## Alternatives considered
<!-- If there are any alternative ways of implementing this that you thought of, but decided against, list them here along with why they were discarded -->
Changing to just using the usernames, but this wouldn't look as nice or be in line with what people expect, plus the per-server nicknames being supported previously suggest that this PR is in line with what was originally intended.

## Open questions
<!-- List any questions you have -->
Do we go with using the nicer names or enforce the usernames for moderation purposes?  If we enforce the usernames, the companion PR should be modified to do the same.

## Additional details or related context
<!-- Give any other details that you think the reviewers should be aware of -->
It is unlikely that the username will ever be used because the global name should always be set.

Depends on: https://github.com/Hubs-Foundation/reticulum/pull/733
[Diff of only changes from this PR](https://github.com/Hubs-Foundation/reticulum/compare/Exairnous:update-discord-api-to-v10...Exairnous:use-discord-display-names)

Companion PR to https://github.com/Hubs-Foundation/hubs-discord-bot/pull/148