### PR TITLE
Fix user permissions bug for Discord bound rooms

### DIFF
--- a/lib/ret/discord_client.ex
+++ b/lib/ret/discord_client.ex
@@ -178,8 +178,8 @@ defmodule Ret.DiscordClient do
 
       permissions = user_permissions |>
       Enum.reduce(permissions, &(
-      if is_binary(&1), do: String.to_integer(&1), else: &1 |||
-      if is_binary(&2), do: String.to_integer(&2), else: &2
+      (if is_binary(&1), do: String.to_integer(&1), else: &1) |||
+      (if is_binary(&2), do: String.to_integer(&2), else: &2)
       ))
 
       if (permissions &&& @administrator) == @administrator do
@@ -210,8 +210,8 @@ defmodule Ret.DiscordClient do
       permissions =
         if overwrite_everyone do
           (permissions &&&
-          ~~~if is_binary(overwrite_everyone["deny"]), do: String.to_integer(overwrite_everyone["deny"]), else: overwrite_everyone["deny"]) |||
-          if is_binary(overwrite_everyone["allow"]), do: String.to_integer(overwrite_everyone["allow"]), else: overwrite_everyone["allow"]
+          ~~~(if is_binary(overwrite_everyone["deny"]), do: String.to_integer(overwrite_everyone["deny"]), else: overwrite_everyone["deny"])) |||
+          (if is_binary(overwrite_everyone["allow"]), do: String.to_integer(overwrite_everyone["allow"]), else: overwrite_everyone["allow"])
         else
           permissions
         end
@@ -221,11 +221,11 @@ defmodule Ret.DiscordClient do
         user_roles |> Enum.map(&channel_overwrites[&1]) |> Enum.filter(&(&1 != nil))
 
       allow = user_permissions |> Enum.reduce(@none, &(
-      if is_binary(&1["allow"]), do: String.to_integer(&1["allow"]), else: &1["allow"] |||
+      (if is_binary(&1["allow"]), do: String.to_integer(&1["allow"]), else: &1["allow"]) |||
       &2
       ))
       deny = user_permissions |> Enum.reduce(@none, &(
-      if is_binary(&1["deny"]), do: String.to_integer(&1["deny"]), else: &1["deny"] |||
+      (if is_binary(&1["deny"]), do: String.to_integer(&1["deny"]), else: &1["deny"]) |||
       &2
       ))
 
@@ -237,8 +237,8 @@ defmodule Ret.DiscordClient do
       permissions =
         if overwrite_member do
           (permissions &&&
-          ~~~if is_binary(overwrite_member["deny"]), do: String.to_integer(overwrite_member["deny"]), else: overwrite_member["deny"]) |||
-          if is_binary(overwrite_member["allow"]), do: String.to_integer(overwrite_member["allow"]), else: overwrite_member["allow"]
+          ~~~(if is_binary(overwrite_member["deny"]), do: String.to_integer(overwrite_member["deny"]), else: overwrite_member["deny"])) |||
+          (if is_binary(overwrite_member["allow"]), do: String.to_integer(overwrite_member["allow"]), else: overwrite_member["allow"])
         else
           permissions
         end


### PR DESCRIPTION
## What?
<!-- REQUIRED — Explain what your pull request does -->
Fixes a bug with getting the permissions of users for Discord bound rooms.  The permissions for the roles a user has weren't getting combined into a single bitfield correctly and instead it seemed that the permissions for just one of the roles was being picked (which may or may not give them all the powers they are supposed to have).  This explicitly specifies the order of operations so that everything gets combined correctly.

## Why?
<!-- REQUIRED — Explain why you're opening this pull request, what limitations does it address, etc..  If you're fixing a bug with an open bug report you can just link to the bug report -->
Users weren't always given the powers they should have been based on their Discord roles, which could prevent moderators and admins from being able to kick users and edit room settings.

## Examples
<!-- If applicable, give examples of your changes, screenshots, videos, etc. -->


## How to test
<!-- REQUIRED — Give the steps required to test your pull request -->

1. Load/Create a Discord bound room from a Discord server where you aren't the owner, but have roles that give you either the ability to kick people or manage channels, on a Hubs instance without the changes in this PR, and enter the room.  (Discord server owners don't run into this bug).
2. See that the permissions specified in https://docs.hubsfoundation.org/hubs-discord-bot.html#user-permissions aren't applied to you.
3. Redeploy the instance with the changes in this PR.
4. Load/Create a Discord bound room from a Discord server where you aren't the owner, but have roles that give you either the ability to kick people or manage channels, and enter the room.
5. See that the permissions specified in https://docs.hubsfoundation.org/hubs-discord-bot.html#user-permissions are now correctly applied to you.

## Documentation of functionality
<!-- REQUIRED — Link to the accompanying documentation pull request or identify where the documentation is located in this pull request.  If no documentation is needed, please specify this here -->
None needed.  This is a fix for incorrect behaviour.

## Limitations
<!-- List anything that isn't addressed, e.g. corner cases, and why they weren't addressed -->
None.

## Alternatives considered
<!-- If there are any alternative ways of implementing this that you thought of, but decided against, list them here along with why they were discarded -->
None.

## Open questions
<!-- List any questions you have -->
None.

## Additional details or related context
<!-- Give any other details that you think the reviewers should be aware of -->
The bug was introduced when the Discord API version was updated and the handling for Discord sometimes sending strings and sometimes sending integers was added.

PR that introduced the bug: https://github.com/Hubs-Foundation/reticulum/pull/733
