### PR TITLE
Switch fread in storage_used.ex back to using a character list

### DIFF
--- a/lib/ret/storage_used.ex
+++ b/lib/ret/storage_used.ex
@@ -29,7 +29,7 @@ defmodule Ret.StorageUsed do
           line = lines |> String.split("\n") |> Enum.at(1)
 
           {:ok, [_FS, _kb, used, _Avail], _RestStr} =
-            :io_lib.fread("~s~d~d~d", line |> to_charlist)
+            :io_lib.fread(~c"~s~d~d~d", line |> to_charlist)
 
           {:ok, [{:storage_used, used}]}
 


### PR DESCRIPTION
## What?
<!-- REQUIRED — Explain what your pull request does -->
Changes the format string that is passed to the io_lib.fread function from a binary/UTF-8 encoded string back to a character list, but uses the character list sigil syntax, rather than single quotes, to make `mix format` happy.

## Why?
<!-- REQUIRED — Explain why you're opening this pull request, what limitations does it address, etc..  If you're fixing a bug with an open bug report you can just link to the bug report -->
Hubs Compose throws errors when io_lib.fread is passed a binary/UTF-8 encoded string, rather than a character list.

## Examples
<!-- If applicable, give examples of your changes, screenshots, videos, etc. -->
N/A

## How to test
<!-- REQUIRED — Give the steps required to test your pull request -->

1. Run this PR using Hubs Compose.
2. See that Hubs Compose now works.  Previously, Reticulum would fail to start in Hubs Compose and complain of `fread` errors in the logs (specifically: `** (FunctionClauseError) no function clause matching in :io_lib_fread.fread/4`).
3. Deploy this PR to a Hubs Community Edition instance.
4. See that the instance continues to function normally.

## Documentation of functionality
<!-- REQUIRED — Link to the accompanying documentation pull request or identify where the documentation is located in this pull request.  If no documentation is needed, please specify this here -->
This PR doesn't add, remove, or change the behavior of any Hubs functionality, so no documentation updates are needed. 

## Limitations
<!-- List anything that isn't addressed, e.g. corner cases, and why they weren't addressed -->
None known.

## Alternatives considered
<!-- If there are any alternative ways of implementing this that you thought of, but decided against, list them here along with why they were discarded -->
Modifying Hubs Compose to work with the new Reticulum code, however I think this would require switching Hubs Compose to use the release configuration of Reticulum, which I don't think we want to do and would be a much bigger change.

## Open questions
<!-- List any questions you have -->
Why this was an issue in the first place.  My theory is that since Community Edition instances don't have any issues with the format string being a binary/UTF-8 encoded string that the issue with Hubs Compose is because Hubs Compose uses the dev build stage in the Reticulum Dockerfile and it's being stricter about the types passed to functions.  But I'm not familiar enough with Erlang/Elixir to say for sure.

## Additional details or related context
<!-- Give any other details that you think the reviewers should be aware of -->
Relates to: https://github.com/Hubs-Foundation/reticulum/pull/738 and a86014d8f15f13b2e6194375ada087be199effca

From what I can tell the `string` io_lib.fread is looking for is synonymous with a character list.

References:
https://www.erlang.org/doc/apps/stdlib/io_lib.html#fread/2
https://www.erlang.org/doc/apps/erts/erlang#t:string/0
https://www.erlang.org/doc/apps/erts/erlang#t:binary/0
https://stackoverflow.com/questions/18756293/elixir-io-lib-call-to-erlang
https://stackoverflow.com/questions/29567049/elixir-calling-io-lib-fread

Full error text:
```
reticulum-1  | [error] GenServer #PID<0.885.0> terminating
reticulum-1  | ** (FunctionClauseError) no function clause matching in :io_lib_fread.fread/4
reticulum-1  |     (stdlib 4.3.1.6) io_lib_fread.erl:115: :io_lib_fread.fread("~s~d~d~d", ~c"/dev/nvme0n1p2       1885483512 180020044 1705463468  10% /code", 0, [])
reticulum-1  |     (ret 1.0.0) lib/ret/storage_used.ex:32: Ret.StorageUsed.execute/1
reticulum-1  |     (ret 1.0.0) deps/cachex/lib/cachex/warmer.ex:79: Ret.StorageUsed.handle_info/2
reticulum-1  |     (stdlib 4.3.1.6) gen_server.erl:1123: :gen_server.try_dispatch/4
reticulum-1  |     (stdlib 4.3.1.6) gen_server.erl:1200: :gen_server.handle_msg/6
reticulum-1  |     (stdlib 4.3.1.6) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
reticulum-1  | Last message: :cachex_warmer
reticulum-1  | State: {{:cache, :storage_used, %{}, false, {:expiration, nil, 3000, true}, {:fallback, nil, nil}, {:hooks, [], []}, {:limit, nil, Cachex.Policy.LRW, 0.1, []}, [:nonode@nohost], false, [{:warmer, Ret.StorageUsed, nil}]}, nil}
reticulum-1  | [notice] Application ret exited: shutdown
reticulum-1  | [debug] Tzdata polling for update.
reticulum-1  | [debug] Tzdata polling shows the loaded tz database is up to date.
```